### PR TITLE
doc(README): add AUR option to installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,14 @@ to verify if the installation went thru, you can run `which stegano` that should
 $HOME/.cargo/bin/stegano
 ```
 
+### AUR
+
+`stegano` can be installed from available [AUR packages](https://aur.archlinux.org/packages/?O=0&SeB=b&K=stegano&outdated=&SB=n&SO=a&PP=50&do_Search=Go) using an [AUR helper](https://wiki.archlinux.org/index.php/AUR_helpers). For example,
+
+```
+yay -S stegano
+```
+
 ## Usage
 
 ```sh


### PR DESCRIPTION
Hi,
I'm a Rust developer who [maintains](https://github.com/orhun/PKGBUILDs) [AUR](https://wiki.archlinux.org/index.php/Arch_User_Repository) packages in his spare time. Recently I came across this project and I liked its concept and implementation. Thus I created the following packages for the installation of `stegano` on Arch Linux and other distributions that support installing packages from [AUR](https://aur.archlinux.org/):

* [stegano](https://aur.archlinux.org/packages/stegano/) (builds from source)
* [stegano-git](https://aur.archlinux.org/packages/stegano-git/) (development package)

This PR basically adds a section to [README.md](https://github.com/steganogram/stegano-rs/blob/main/README.md#install) about installation from AUR.

Take care,
orhun.