### PR TITLE
fix(cli): Fixed errors that prevented the use of the entire program

### DIFF
--- a/stegano-cli/src/main.rs
+++ b/stegano-cli/src/main.rs
@@ -103,7 +103,7 @@ fn main() -> Result<()> {
 
     match matches.subcommand() {
         Some(("hide", m)) => {
-            let mut s = SteganoCore::encoder_with_options(get_options(m));
+            let mut s = SteganoCore::encoder_with_options(get_options(&matches));
 
             s.use_media(m.get_one::<String>("media").unwrap())?
                 .write_to(m.get_one::<String>("write_to_file").unwrap());
@@ -112,8 +112,8 @@ fn main() -> Result<()> {
                 s.hide_message(msg);
             }
 
-            if let Some(files) = m.get_many("data_file") {
-                s.hide_files(files.copied().collect());
+            if let Some(files) = m.get_many::<String>("data_file") {
+                s.hide_files(files.map(|f| &**f).collect());
             }
 
             if m.contains_id("force_content_version2") {
@@ -126,7 +126,7 @@ fn main() -> Result<()> {
             unveil(
                 Path::new(m.get_one::<String>("input_image").unwrap()),
                 Path::new(m.get_one::<String>("output_folder").unwrap()),
-                &get_options(m),
+                &get_options(&matches),
             )?;
         }
         Some(("unveil-raw", m)) => {

--- a/stegano-core/src/bit_iterator.rs
+++ b/stegano-core/src/bit_iterator.rs
@@ -33,7 +33,7 @@ where
             if bit == 0 {
                 self.byte = None;
             }
-            if self.byte == None {
+            if self.byte.is_none() {
                 let mut b = 0;
                 match self.iter.read(slice::from_mut(&mut b)) {
                     Ok(0) => None,

--- a/stegano-core/src/message.rs
+++ b/stegano-core/src/message.rs
@@ -204,7 +204,7 @@ impl From<&Message> for Vec<u8> {
                     .map(|(name, buf)| (name, buf))
                     .for_each(|(name, buf)| {
                         zip.start_file(name, options)
-                            .unwrap_or_else(|_| panic!("processing file '{}' failed.", name));
+                            .unwrap_or_else(|_| panic!("processing file '{name}' failed."));
 
                         let mut r = std::io::Cursor::new(buf);
                         std::io::copy(&mut r, &mut zip)

--- a/stegano-core/src/universal_encoder.rs
+++ b/stegano-core/src/universal_encoder.rs
@@ -20,7 +20,7 @@ pub enum HideAlgorithms {
 #[enum_dispatch(HideAlgorithms)]
 pub trait HideAlgorithm {
     /// encodes one bit onto a carrier T e.g. u8 or i16
-    fn encode<'c>(&self, carrier: MediaPrimitiveMut<'c>, information: &Result<bool>);
+    fn encode(&self, carrier: MediaPrimitiveMut, information: &Result<bool>);
 }
 
 /// generic stegano encoder
@@ -72,7 +72,7 @@ where
 pub struct OneBitHide;
 impl HideAlgorithm for OneBitHide {
     #[inline(always)]
-    fn encode<'c>(&self, carrier: MediaPrimitiveMut<'c>, information: &Result<bool>) {
+    fn encode(&self, carrier: MediaPrimitiveMut, information: &Result<bool>) {
         if let Ok(bit) = information {
             match carrier {
                 MediaPrimitiveMut::ImageColorChannel(b) => {
@@ -92,7 +92,7 @@ impl HideAlgorithm for OneBitHide {
 pub struct OneBitInLowFrequencyHide;
 impl HideAlgorithm for OneBitInLowFrequencyHide {
     #[inline(always)]
-    fn encode<'c>(&self, carrier: MediaPrimitiveMut<'c>, information: &Result<bool>) {
+    fn encode(&self, carrier: MediaPrimitiveMut, information: &Result<bool>) {
         if let Ok(bit) = information {
             match carrier {
                 MediaPrimitiveMut::ImageColorChannel(b) => {


### PR DESCRIPTION
Hello,
In this PR I have fixed two errors that I was encountering when running the program :

1. it crashes instantly when I run it because the color_step_increment argument is requested but is not present in the argument list of one of the subcommands
2. even after fixing this, I could not use the data_file argument (error below) so I had to remake the `Vec<String>` to `Vec<&str>` conversion
```
thread 'main' panicked at 'Mismatch between definition and access of `data_file`. Could not downcast to TypeId { t: 9919015677752515272 }, need to downcast to TypeId { t: 5770869618381768169 }
', C:\Users\alexi\.cargo\registry\src\github.com-1ecc6299db9ec823\clap-4.1.4\src\parser\error.rs:30:9
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```